### PR TITLE
Add billing service test

### DIFF
--- a/billing-service/pom.xml
+++ b/billing-service/pom.xml
@@ -47,6 +47,13 @@
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-stream-rabbit</artifactId>
     </dependency>
+
+    <!-- Testing -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/billing-service/src/test/java/com/smarttel/billing/service/BillingServiceTest.java
+++ b/billing-service/src/test/java/com/smarttel/billing/service/BillingServiceTest.java
@@ -1,0 +1,43 @@
+package com.smarttel.billing.service;
+
+import com.smarttel.billing.model.Billing;
+import com.smarttel.billing.repository.BillingRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class BillingServiceTest {
+
+    @Mock
+    private BillingRepository repository;
+
+    @InjectMocks
+    private BillingService billingService;
+
+    @Test
+    public void createBilling_savesBillingWithExpectedFields() {
+        Long customerId = 42L;
+        Billing saved = new Billing(customerId, BigDecimal.valueOf(99.99));
+        when(repository.save(any(Billing.class))).thenReturn(saved);
+
+        Billing result = billingService.createBilling(customerId);
+
+        ArgumentCaptor<Billing> captor = ArgumentCaptor.forClass(Billing.class);
+        verify(repository).save(captor.capture());
+        Billing captured = captor.getValue();
+
+        assertEquals(customerId, captured.getCustomerId());
+        assertEquals(new BigDecimal("99.99"), captured.getAmount());
+        assertSame(saved, result);
+    }
+}


### PR DESCRIPTION
## Summary
- add Spring Boot test starter dependency to billing service
- test `BillingService.createBilling` with Mockito

## Testing
- `mvn -f billing-service/pom.xml test -q` *(fails: Non-resolvable parent POM - network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688257132014832dbfdb96d7dc90fd92