### PR TITLE
Add CustomerService unit tests

### DIFF
--- a/customer-service/pom.xml
+++ b/customer-service/pom.xml
@@ -49,6 +49,13 @@
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-stream-rabbit</artifactId>
     </dependency>
+
+    <!-- Testing -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/customer-service/src/main/java/com/smarttel/customer/service/CustomerService.java
+++ b/customer-service/src/main/java/com/smarttel/customer/service/CustomerService.java
@@ -1,0 +1,38 @@
+package com.smarttel.customer.service;
+
+import com.smarttel.customer.model.Customer;
+import com.smarttel.customer.repository.CustomerRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.stream.function.StreamBridge;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class CustomerService {
+
+    private final CustomerRepository repository;
+    private final StreamBridge streamBridge;
+
+    @Autowired
+    public CustomerService(CustomerRepository repository, StreamBridge streamBridge) {
+        this.repository = repository;
+        this.streamBridge = streamBridge;
+    }
+
+    public Customer createCustomer(Customer customer) {
+        if (customer == null) {
+            throw new IllegalArgumentException("customer must not be null");
+        }
+        Customer saved = repository.save(customer);
+        streamBridge.send("customerCreated-out-0", saved);
+        return saved;
+    }
+
+    public Optional<Customer> getCustomer(Long id) {
+        if (id == null) {
+            throw new IllegalArgumentException("id must not be null");
+        }
+        return repository.findById(id);
+    }
+}

--- a/customer-service/src/test/java/com/smarttel/customer/service/CustomerServiceTest.java
+++ b/customer-service/src/test/java/com/smarttel/customer/service/CustomerServiceTest.java
@@ -1,0 +1,78 @@
+package com.smarttel.customer.service;
+
+import com.smarttel.customer.model.Customer;
+import com.smarttel.customer.repository.CustomerRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cloud.stream.function.StreamBridge;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class CustomerServiceTest {
+
+    @Mock
+    private CustomerRepository repository;
+
+    @Mock
+    private StreamBridge streamBridge;
+
+    @InjectMocks
+    private CustomerService service;
+
+    @Test
+    public void createCustomer_persistsAndPublishesEvent() {
+        Customer input = new Customer("Jane", "jane@example.com");
+        Customer saved = new Customer("Jane", "jane@example.com");
+        when(repository.save(any(Customer.class))).thenReturn(saved);
+        when(streamBridge.send(anyString(), any())).thenReturn(true);
+
+        Customer result = service.createCustomer(input);
+
+        ArgumentCaptor<Customer> captor = ArgumentCaptor.forClass(Customer.class);
+        verify(repository).save(captor.capture());
+        verify(streamBridge).send(eq("customerCreated-out-0"), eq(saved));
+
+        assertEquals(input.getName(), captor.getValue().getName());
+        assertEquals(input.getEmail(), captor.getValue().getEmail());
+        assertSame(saved, result);
+    }
+
+    @Test
+    public void createCustomer_nullCustomerThrowsException() {
+        assertThrows(IllegalArgumentException.class, () -> service.createCustomer(null));
+    }
+
+    @Test
+    public void getCustomer_foundReturnsCustomer() {
+        Customer customer = new Customer("Bob", "bob@example.com");
+        when(repository.findById(1L)).thenReturn(Optional.of(customer));
+
+        Optional<Customer> result = service.getCustomer(1L);
+
+        assertTrue(result.isPresent());
+        assertSame(customer, result.get());
+    }
+
+    @Test
+    public void getCustomer_notFoundReturnsEmpty() {
+        when(repository.findById(99L)).thenReturn(Optional.empty());
+
+        Optional<Customer> result = service.getCustomer(99L);
+
+        assertFalse(result.isPresent());
+    }
+
+    @Test
+    public void getCustomer_nullIdThrowsException() {
+        assertThrows(IllegalArgumentException.class, () -> service.getCustomer(null));
+    }
+}


### PR DESCRIPTION
## Summary
- add a new `CustomerService` class to handle customer persistence
- include JUnit and Mockito dependencies in the customer-service module
- implement `CustomerServiceTest` covering common and edge cases

## Testing
- `mvn -q -o -f customer-service/pom.xml test` *(fails: Cannot access repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_688284a2db64832d81fb00210a0e41fd