### PR TITLE
Add NotificationEventListener test

### DIFF
--- a/notification-service/pom.xml
+++ b/notification-service/pom.xml
@@ -36,6 +36,13 @@
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-stream-rabbit</artifactId>
     </dependency>
+
+    <!-- Testing -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/notification-service/src/test/java/com/smarttel/notification/listener/NotificationEventListenerTest.java
+++ b/notification-service/src/test/java/com/smarttel/notification/listener/NotificationEventListenerTest.java
@@ -1,0 +1,42 @@
+package com.smarttel.notification.listener;
+
+import com.smarttel.notification.dto.CustomerDTO;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.function.Consumer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class NotificationEventListenerTest {
+
+    @Mock
+    private CustomerDTO customer;
+
+    @Test
+    public void customerCreatedNotification_logsWelcomeMessage() {
+        when(customer.getId()).thenReturn(123L);
+        NotificationEventListener listener = new NotificationEventListener();
+        Consumer<CustomerDTO> consumer = listener.customerCreatedNotification();
+
+        ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+        PrintStream originalOut = System.out;
+        System.setOut(new PrintStream(outContent));
+        try {
+            consumer.accept(customer);
+        } finally {
+            System.setOut(originalOut);
+        }
+
+        verify(customer).getId();
+        String output = outContent.toString().trim();
+        assertEquals("Notification sent: Welcome, customer ID: 123", output);
+    }
+}


### PR DESCRIPTION
## Summary
- add NotificationEventListenerTest covering log output
- enable tests by adding spring-boot-starter-test to pom

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688284efcf64832d99011e6fd96dff98