### PR TITLE
Fix gateway POM

### DIFF
--- a/api-gateway/pom.xml
+++ b/api-gateway/pom.xml
@@ -31,11 +31,6 @@
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-gateway</artifactId>
     </dependency>
-    <!-- Spring Boot Web Starter -->
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-web</artifactId>
-    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
## Summary
- remove Spring MVC dependency so api-gateway only uses gateway starter

## Testing
- `mvn -q -DskipTests spring-boot:run` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6882861dad04832d8e18f8958b7af3eb