### PR TITLE
Add RabbitMQ env configuration

### DIFF
--- a/billing-service/src/main/resources/application.yml
+++ b/billing-service/src/main/resources/application.yml
@@ -10,6 +10,9 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
+  rabbitmq:
+    host: ${RABBITMQ_HOST:localhost}
+    port: ${RABBITMQ_PORT:5672}
   cloud:
     stream:
       bindings:


### PR DESCRIPTION
## Summary
- allow overriding RabbitMQ host/port for Billing Service via environment variables

## Testing
- `mvn test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688287367e48832dabfab9449e9773eb