### PR TITLE
Document RabbitMQ requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # TEMP TRIGGER
+
+## Running Services Locally
+
+A RabbitMQ broker must be available on `localhost:5672` for the services to communicate using Spring Cloud Stream. You can start a RabbitMQ container using Docker Compose:
+
+```bash
+docker-compose up -d rabbitmq
+```
+
+After RabbitMQ is running, the notification service can be started with Maven:
+
+```bash
+cd notification-service
+mvn spring-boot:run
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3.8'
+services:
+  rabbitmq:
+    image: rabbitmq:3-management
+    ports:
+      - "5672:5672"
+      - "15672:15672"


### PR DESCRIPTION
## Summary
- document how to run RabbitMQ locally for the services
- provide docker-compose snippet for RabbitMQ

## Testing
- `mvn -q package -DskipTests` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68828791402c832da37cab4e5cc957e5