### PR TITLE
Add context loading tests and update workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -21,21 +21,25 @@ jobs:
       - name: Build Customer Service
         run: |
           cd customer-service
+          mvn test
           mvn clean package -DskipTests
 
       - name: Build Billing Service
         run: |
           cd billing-service
+          mvn test
           mvn clean package -DskipTests
 
       - name: Build Notification Service
         run: |
           cd notification-service
+          mvn test
           mvn clean package -DskipTests
 
       - name: Build API Gateway
         run: |
           cd api-gateway
+          mvn test
           mvn clean package -DskipTests
 
       - name: Build Docker Images

--- a/api-gateway/pom.xml
+++ b/api-gateway/pom.xml
@@ -36,6 +36,18 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
+    <!-- Testing -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-stream</artifactId>
+      <classifier>test-binder</classifier>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/api-gateway/src/test/java/com/smarttel/gateway/ApiGatewayApplicationTests.java
+++ b/api-gateway/src/test/java/com/smarttel/gateway/ApiGatewayApplicationTests.java
@@ -1,0 +1,10 @@
+package com.smarttel.gateway;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(properties = "spring.cloud.stream.defaultBinder=test")
+class ApiGatewayApplicationTests {
+    @Test
+    void contextLoads() {}
+}

--- a/billing-service/pom.xml
+++ b/billing-service/pom.xml
@@ -54,6 +54,12 @@
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-stream</artifactId>
+      <classifier>test-binder</classifier>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/billing-service/src/test/java/com/smarttel/billing/BillingServiceApplicationTests.java
+++ b/billing-service/src/test/java/com/smarttel/billing/BillingServiceApplicationTests.java
@@ -1,0 +1,10 @@
+package com.smarttel.billing;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(properties = "spring.cloud.stream.defaultBinder=test")
+class BillingServiceApplicationTests {
+    @Test
+    void contextLoads() {}
+}

--- a/customer-service/pom.xml
+++ b/customer-service/pom.xml
@@ -49,6 +49,18 @@
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-stream-rabbit</artifactId>
     </dependency>
+    <!-- Testing -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-stream</artifactId>
+      <classifier>test-binder</classifier>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/customer-service/src/test/java/com/smarttel/customer/CustomerServiceApplicationTests.java
+++ b/customer-service/src/test/java/com/smarttel/customer/CustomerServiceApplicationTests.java
@@ -1,0 +1,10 @@
+package com.smarttel.customer;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(properties = "spring.cloud.stream.defaultBinder=test")
+class CustomerServiceApplicationTests {
+    @Test
+    void contextLoads() {}
+}

--- a/notification-service/pom.xml
+++ b/notification-service/pom.xml
@@ -36,6 +36,18 @@
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-stream-rabbit</artifactId>
     </dependency>
+    <!-- Testing -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-stream</artifactId>
+      <classifier>test-binder</classifier>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/notification-service/src/test/java/com/smarttel/notification/NotificationServiceApplicationTests.java
+++ b/notification-service/src/test/java/com/smarttel/notification/NotificationServiceApplicationTests.java
@@ -1,0 +1,10 @@
+package com.smarttel.notification;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(properties = "spring.cloud.stream.defaultBinder=test")
+class NotificationServiceApplicationTests {
+    @Test
+    void contextLoads() {}
+}


### PR DESCRIPTION
## Summary
- add Spring context load tests for each service
- include spring-boot-starter-test and test binder dependencies in service POMs
- run `mvn test` in CI before packaging services

## Testing
- `mvn test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688275b4a1a0832d9b2a5889035cf0f7