### PR TITLE
Add dockerignore to services

### DIFF
--- a/api-gateway/.dockerignore
+++ b/api-gateway/.dockerignore
@@ -1,0 +1,13 @@
+# Maven build directory
+target/
+
+# Git repository
+.git/
+
+# IDE directories and files
+.idea/
+.vscode/
+*.iml
+.classpath
+.project
+.settings/

--- a/billing-service/.dockerignore
+++ b/billing-service/.dockerignore
@@ -1,0 +1,13 @@
+# Maven build directory
+target/
+
+# Git repository
+.git/
+
+# IDE directories and files
+.idea/
+.vscode/
+*.iml
+.classpath
+.project
+.settings/

--- a/customer-service/.dockerignore
+++ b/customer-service/.dockerignore
@@ -1,0 +1,13 @@
+# Maven build directory
+target/
+
+# Git repository
+.git/
+
+# IDE directories and files
+.idea/
+.vscode/
+*.iml
+.classpath
+.project
+.settings/

--- a/notification-service/.dockerignore
+++ b/notification-service/.dockerignore
@@ -1,0 +1,13 @@
+# Maven build directory
+target/
+
+# Git repository
+.git/
+
+# IDE directories and files
+.idea/
+.vscode/
+*.iml
+.classpath
+.project
+.settings/


### PR DESCRIPTION
## Summary
- add `.dockerignore` files to Maven services

## Testing
- `mvn -B test` *(fails: Non-resolvable parent POM, network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688275ae9788832d87d2dd7f019201cf