### PR TITLE
Allow mocking of final StreamBridge in tests

### DIFF
--- a/customer-service/pom.xml
+++ b/customer-service/pom.xml
@@ -27,12 +27,12 @@
     </dependencies>
   </dependencyManagement>
 
-  <dependencies>
-    <!-- Spring Boot Web Starter -->
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-web</artifactId>
-    </dependency>
+    <dependencies>
+      <!-- Spring Boot Web Starter -->
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-web</artifactId>
+      </dependency>
     <!-- Spring Data JPA Starter -->
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -49,13 +49,25 @@
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-stream-rabbit</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.springframework.cloud</groupId>
-      <artifactId>spring-cloud-stream-test-binder</artifactId>
-      <version>4.3.0</version>
-      <scope>test</scope>
-    </dependency>
-  </dependencies>
+      <dependency>
+        <groupId>org.springframework.cloud</groupId>
+        <artifactId>spring-cloud-stream-test-binder</artifactId>
+        <version>4.3.0</version>
+        <scope>test</scope>
+      </dependency>
+      <!-- Test utilities -->
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-test</artifactId>
+        <scope>test</scope>
+      </dependency>
+      <!-- Allows Mockito to mock final classes like StreamBridge -->
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-inline</artifactId>
+        <scope>test</scope>
+      </dependency>
+    </dependencies>
 
   <build>
     <plugins>


### PR DESCRIPTION
## Summary
- add missing test dependencies for customer-service
- include `mockito-inline` so final classes like `StreamBridge` can be mocked

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6882c148abb0832d82067ca0b193ebc5